### PR TITLE
Fix zsh compinit warnings and duplicate initialization

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,8 +1,6 @@
 # If you come from bash you might have to change your $PATH.
 export PATH=$HOME/bin:/usr/local/bin:$HOME/nand2tetris/tools:$PATH
 
-ZSH_DISABLE_COMPFIX=true
-
 # Path to your oh-my-zsh installation.
 export ZSH="/Users/ab/.oh-my-zsh"
 
@@ -139,4 +137,4 @@ function d() {
 export PATH="$HOME/.local/bin:$PATH"
 
 # Entire CLI shell completion
-autoload -Uz compinit && compinit && source <(entire completion zsh)
+source <(entire completion zsh)


### PR DESCRIPTION
## Summary
- Re-enable oh-my-zsh's `compinit` security audit by removing `ZSH_DISABLE_COMPFIX=true`
- Remove redundant `compinit` call from Entire CLI completion line, which was causing `/dev/fd/12` errors on shell startup

## Test plan
- [x] Open new terminal — no compinit warnings
- [x] Open new terminal — no `/dev/fd/12` errors
- [x] Tab completion works for `entire` CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)