### PR TITLE
Enable useful oh-my-zsh options and set EDITOR

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -21,7 +21,7 @@ ZSH_THEME="robbyrussell"
 
 # Uncomment the following line to use hyphen-insensitive completion.
 # Case-sensitive completion must be off. _ and - will be interchangeable.
-# HYPHEN_INSENSITIVE="true"
+HYPHEN_INSENSITIVE="true"
 
 # Uncomment the following line to disable bi-weekly auto-update checks.
 # DISABLE_AUTO_UPDATE="true"
@@ -39,7 +39,7 @@ ZSH_THEME="robbyrussell"
 # DISABLE_LS_COLORS="true"
 
 # Uncomment the following line to disable auto-setting terminal title.
-# DISABLE_AUTO_TITLE="true"
+DISABLE_AUTO_TITLE="true"
 
 # Uncomment the following line to enable command auto-correction.
 # ENABLE_CORRECTION="true"
@@ -47,12 +47,12 @@ ZSH_THEME="robbyrussell"
 # Uncomment the following line to display red dots whilst waiting for completion.
 # Caution: this setting can cause issues with multiline prompts (zsh 5.7.1 and newer seem to work)
 # See https://github.com/ohmyzsh/ohmyzsh/issues/5765
-# COMPLETION_WAITING_DOTS="true"
+COMPLETION_WAITING_DOTS="true"
 
 # Uncomment the following line if you want to disable marking untracked files
 # under VCS as dirty. This makes repository status check for large repositories
 # much, much faster.
-# DISABLE_UNTRACKED_FILES_DIRTY="true"
+DISABLE_UNTRACKED_FILES_DIRTY="true"
 
 # Uncomment the following line if you want to change the command execution time
 # stamp shown in the history command output.
@@ -60,7 +60,7 @@ ZSH_THEME="robbyrussell"
 # "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
 # or set a custom format using the strftime function format specifications,
 # see 'man strftime' for details.
-# HIST_STAMPS="mm/dd/yyyy"
+HIST_STAMPS="yyyy-mm-dd"
 
 # Would you like to use another custom folder than $ZSH/custom?
 # ZSH_CUSTOM=/path/to/new-custom-folder
@@ -81,12 +81,7 @@ source $ZSH/oh-my-zsh.sh
 # You may need to manually set your language environment
 # export LANG=en_US.UTF-8
 
-# Preferred editor for local and remote sessions
-# if [[ -n $SSH_CONNECTION ]]; then
-#   export EDITOR='vim'
-# else
-#   export EDITOR='mvim'
-# fi
+export EDITOR='vim'
 
 # Compilation flags
 # export ARCHFLAGS="-arch x86_64"


### PR DESCRIPTION
## Summary
- **HYPHEN_INSENSITIVE**: `_` and `-` interchangeable in tab completion (e.g., `vue_cli` matches `vue-cli`)
- **DISABLE_AUTO_TITLE**: Lets tmux control terminal title without zsh overriding it
- **COMPLETION_WAITING_DOTS**: Shows `...` during slow tab completions instead of frozen terminal
- **DISABLE_UNTRACKED_FILES_DIRTY**: Faster git prompt in large repos by skipping untracked file checks
- **HIST_STAMPS**: ISO date format (`yyyy-mm-dd`) in `history` output
- **EDITOR=vim**: Default editor for git commit, crontab, and other CLI tools

Also removed the commented-out editor boilerplate (SSH-conditional mvim/vim block) since a simple `export EDITOR='vim'` covers all cases.

## Test plan
- [x] Shell starts cleanly (~0.6s, no regressions from nvm lazy-load)
- [x] No errors or warnings on startup

Fixes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)