### PR TITLE
Add Hyper+A and Hyper+E for line navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,13 @@ macOS automation and window management. Requires the **Hyper key** (`Ctrl + Alt 
 |----------|--------|
 | `Hyper + Return` | Toggle Raycast |
 
+### Line Navigation
+
+| Shortcut | Action |
+|----------|--------|
+| `Hyper + a` | Beginning of line (`Ctrl+A`) |
+| `Hyper + e` | End of line (`Ctrl+E`) |
+
 ### Utilities
 
 | Shortcut | Action |

--- a/hammerspoon/.hammerspoon/init.lua
+++ b/hammerspoon/.hammerspoon/init.lua
@@ -95,6 +95,19 @@ end)
 
 
 --------------------------------------------------
+-- Hyper + A / Hyper + E: Line navigation
+-- Maps CapsLock+A/E to Ctrl+A/E (beginning/end of line)
+--------------------------------------------------
+
+hs.hotkey.bind(hyper, "a", function()
+  hs.eventtap.keyStroke({ "ctrl" }, "a")
+end)
+
+hs.hotkey.bind(hyper, "e", function()
+  hs.eventtap.keyStroke({ "ctrl" }, "e")
+end)
+
+--------------------------------------------------
 -- Hyper + V: Paste into fields where paste is disabled
 -- Types clipboard contents character by character
 --------------------------------------------------


### PR DESCRIPTION
## Summary

- Map `Hyper+A` → `Ctrl+A` (beginning of line)
- Map `Hyper+E` → `Ctrl+E` (end of line)

Closes #16

## Test plan

- [ ] Press `CapsLock+A` — cursor moves to beginning of line
- [ ] Press `CapsLock+E` — cursor moves to end of line
- [ ] Reload Hammerspoon config with `Hyper+R` and verify bindings work

🤖 Generated with [Claude Code](https://claude.com/claude-code)