### PR TITLE
Add issue-driven workflow instructions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,7 @@ vim +PlugInstall +qall     # Install new plugins
 
 ### For Claude Code
 
+- **GitHub issue-driven workflow**: Before starting work on ANY change, ALWAYS create a GitHub issue first with a detailed description of what will be changed and why. Then create a new branch from `main` for the work. After completing and committing the changes, push the branch to the remote, create a pull request, merge it to `main`, and ensure the GitHub issue is closed. Every change — no matter how small — must follow this workflow: issue → branch → commit → push → merge → close issue. Do this automatically without waiting for the user to ask.
 - **Never commit secrets**: Before every commit, scan staged files for API keys, tokens, passwords, private keys, and credentials (e.g. `.env`, `*.token`, `*.pem`, `credentials.json`, `~/.ssh/*`). If any secret or sensitive value is detected, STOP and warn the user immediately — do NOT proceed with the commit
 - **Prefer editing over creating**: Edit existing configs rather than creating new files
 - **Test before committing**: Configs are live-linked via Stow, so test changes immediately


### PR DESCRIPTION
## Summary

- Add instruction requiring all changes follow: issue → branch → commit → push → merge → close issue
- Claude will now automatically follow this workflow without needing explicit instructions each time

Closes #18

## Test plan

- [ ] Verify CLAUDE.md contains the new workflow instruction as the first bullet under "For Claude Code"
- [ ] Confirm future conversations pick up the instruction and follow the workflow automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)