### PR TITLE
Add Hyper+B and Hyper+W for word jumping

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ macOS automation and window management. Requires the **Hyper key** (`Ctrl + Alt 
 |----------|--------|
 | `Hyper + a` | Beginning of line (`Ctrl+A`) |
 | `Hyper + e` | End of line (`Ctrl+E`) |
+| `Hyper + b` | Jump one word backward (`Ctrl+B` → zsh `backward-word`) |
+| `Hyper + w` | Jump one word forward (`Ctrl+F` → zsh `forward-word`) |
 
 ### Utilities
 

--- a/hammerspoon/.hammerspoon/hyper_vim.lua
+++ b/hammerspoon/.hammerspoon/hyper_vim.lua
@@ -122,6 +122,24 @@ function M.start(opts)
       return true
     end
 
+    -- Hyper+B/W: word jumping via Ctrl+B / Ctrl+F.
+    -- Sending Option+Arrow or Esc+letter from an eventtap is unreliable
+    -- because terminals can't properly receive modifier flags or multi-key
+    -- sequences from synthetic events. Instead, we send Ctrl+B/F (which
+    -- works the same way as the proven Ctrl+A/E) and rebind them in zsh
+    -- from single-char movement to word movement (the user already has
+    -- Hyper+H/L for single-char navigation via arrow keys).
+    if key == "b" then
+      local events = sendCtrlKey("b")
+      if events then return true, events end
+      return true
+    end
+    if key == "w" then
+      local events = sendCtrlKey("f")
+      if events then return true, events end
+      return true
+    end
+
     -- Ignore keys other than h/j/k/l.
     if key ~= "h" and key ~= "j" and key ~= "k" and key ~= "l" then
       return false

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -74,6 +74,12 @@ plugins=(git autojump)
 
 source $ZSH/oh-my-zsh.sh
 
+# Rebind Ctrl+B/F from single-char to word movement.
+# Single-char movement is handled by Hyper+H/L (arrow keys via Hammerspoon).
+# Hyper+B sends Ctrl+B and Hyper+W sends Ctrl+F through the eventtap.
+bindkey '^B' backward-word
+bindkey '^F' forward-word
+
 # User configuration
 
 # export MANPATH="/usr/local/man:$MANPATH"


### PR DESCRIPTION
## Summary

- `Hyper+B` → jump one word backward
- `Hyper+W` → jump one word forward
- Uses `Ctrl+B`/`Ctrl+F` via the proven eventtap mechanism + zsh bindkey rebindings
- Previous approaches (Option+Arrow, Esc+b/f) failed due to synthetic event limitations

Closes #24

## Test plan

- [x] `CapsLock+B` jumps backward one word in terminal
- [x] `CapsLock+W` jumps forward one word in terminal
- [x] `CapsLock+H`/`CapsLock+L` still work for single-char movement

🤖 Generated with [Claude Code](https://claude.com/claude-code)