### PR TITLE
Add global Claude Code instructions via stow package

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Personal macOS dotfiles managed with [GNU Stow](https://www.gnu.org/software/sto
 
 ```
 dotfiles/
+├── claude/         # Global Claude Code instructions
 ├── hammerspoon/    # macOS automation & window management
 ├── tmux/           # Terminal multiplexer
 ├── vim/            # Vim editor
@@ -18,6 +19,14 @@ dotfiles/
 cd ~/dotfiles
 stow <package>    # e.g. stow vim, stow zsh
 ```
+
+## Claude Code
+
+Global instructions for [Claude Code](https://claude.com/claude-code) that apply to all projects. Symlinks `~/.claude/CLAUDE.md`.
+
+**Rules**:
+- Never commit secrets or sensitive information (API keys, tokens, passwords, private keys)
+- Python projects: always use a virtual environment and maintain `requirements.txt`
 
 ## Vim
 

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -1,0 +1,10 @@
+# Global Claude Code Instructions
+
+## Security
+
+- **Never commit secrets**: Before every commit, scan staged files for API keys, tokens, passwords, private keys, and credentials (e.g. `.env`, `*.token`, `*.pem`, `credentials.json`, `~/.ssh/*`). If any secret or sensitive value is detected, STOP and warn the user immediately — do NOT proceed with the commit.
+
+## Python
+
+- **Always use a virtual environment**: When working on a Python project, ensure a virtual environment exists (e.g. `venv/`). If one doesn't exist, create it before installing any packages.
+- **Always maintain requirements.txt**: Keep a `requirements.txt` file with pinned dependencies. Update it whenever packages are added or removed.


### PR DESCRIPTION
## Summary
- Adds a `claude` stow package that symlinks `~/.claude/CLAUDE.md` for global Claude Code instructions
- Two rules: never commit secrets, and always use venv + requirements.txt for Python projects
- Updates README.md with the new package

Closes #30

## Test plan
- [x] Ran `stow claude` — symlink created at `~/.claude/CLAUDE.md`
- [x] Verified file contents via `~/.claude/CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)