### PR TITLE
Add Hyper+U and Hyper+X for terminal line deletion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ Each directory contains dotfiles that Stow will symlink to `~` (home directory).
   - `Hyper+Space`: Move window to next monitor
 - **Quick Actions**:
   - `Hyper+Return`: Toggle Raycast
+  - `Hyper+U`: Delete to beginning of line (`Ctrl+U`)
+  - `Hyper+X`: Delete to end of line (`Ctrl+K`)
   - `Hyper+V`: Force paste (bypasses paste restrictions)
   - `Hyper+R`: Reload Hammerspoon config
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ macOS automation and window management. Requires the **Hyper key** (`Ctrl + Alt 
 | `Hyper + b` | Jump one word backward (`Ctrl+B` → zsh `backward-word`) |
 | `Hyper + w` | Jump one word forward (`Ctrl+F` → zsh `forward-word`) |
 | `Hyper + d` | Delete word under cursor (`Ctrl+G` → zsh custom widget) |
+| `Hyper + u` | Delete to beginning of line (`Ctrl+U` → zsh `backward-kill-line`) |
+| `Hyper + x` | Delete to end of line (`Ctrl+K`) |
 
 ### Utilities
 

--- a/hammerspoon/.hammerspoon/hyper_vim.lua
+++ b/hammerspoon/.hammerspoon/hyper_vim.lua
@@ -149,6 +149,21 @@ function M.start(opts)
       return true
     end
 
+    -- Hyper+U/X: delete to beginning/end of line.
+    -- Ctrl+K is zsh's default kill-line (cursor to end).
+    -- Ctrl+U is rebound in zsh from kill-whole-line to backward-kill-line
+    -- (cursor to beginning) so it complements Ctrl+K.
+    if key == "u" then
+      local events = sendCtrlKey("u")
+      if events then return true, events end
+      return true
+    end
+    if key == "x" then
+      local events = sendCtrlKey("k")
+      if events then return true, events end
+      return true
+    end
+
     -- Ignore keys other than h/j/k/l.
     if key ~= "h" and key ~= "j" and key ~= "k" and key ~= "l" then
       return false

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -79,6 +79,7 @@ source $ZSH/oh-my-zsh.sh
 # Hyper+B sends Ctrl+B and Hyper+W sends Ctrl+F through the eventtap.
 bindkey '^B' backward-word
 bindkey '^F' forward-word
+bindkey '^U' backward-kill-line
 
 # Delete word under cursor (Hyper+D sends Ctrl+G via Hammerspoon).
 delete-word-under-cursor() {


### PR DESCRIPTION
## Summary
- **Hyper+U**: Delete from cursor to beginning of line (`Ctrl+U` → zsh `backward-kill-line`)
- **Hyper+X**: Delete from cursor to end of line (`Ctrl+K` → zsh `kill-line`)
- Rebinds `Ctrl+U` in zsh from `kill-whole-line` to `backward-kill-line` so the two shortcuts complement each other

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)