### PR TITLE
Add mnemonic guide for terminal navigation shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ macOS automation and window management. Requires the **Hyper key** (`Ctrl + Alt 
 | `Hyper + u` | Delete to beginning of line (`Ctrl+U` → zsh `backward-kill-line`) |
 | `Hyper + x` | Delete to end of line (`Ctrl+K`) |
 
+> **Mnemonic**: **B**ack a word / forward a **W**ord. **D**elete the word. **U**ndo what you typed (wipes left). **X** out the rest (wipes right).
+
 ### Utilities
 
 | Shortcut | Action |


### PR DESCRIPTION
## Summary
- Adds a one-liner mnemonic below the Line Navigation table to help remember the Hyper key shortcuts: **B**ack / **W**ord for movement, **D**elete / **U**ndo / **X** out for deletion

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)