### PR TITLE
Add yoclau alias for Claude with --dangerously-skip-permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Framework: [oh-my-zsh](https://ohmyz.sh/) with the `robbyrussell` theme.
 | `vz` | `z && vim` | Navigate with zoxide then open Vim |
 | `dpush` | `rsync -avzP ~/do-sync/ d:~/do-sync/` | Push files from local Mac to DigitalOcean |
 | `dpull` | `rsync -avzP d:~/do-sync/ ~/do-sync/` | Pull files from DigitalOcean to local Mac |
+| `yoclau` | `claude --dangerously-skip-permissions` | Launch Claude Code with dangerously skip permissions |
 
 ### Functions
 

--- a/zsh/.zsh_aliases
+++ b/zsh/.zsh_aliases
@@ -11,3 +11,6 @@ alias vz='z && vim'
 # -a: archive mode, -v: verbose, -z: compress, -P: show progress/resume
 alias dpush='rsync -avzP ~/do-sync/ d:~/do-sync/'
 alias dpull='rsync -avzP d:~/do-sync/ ~/do-sync/'
+
+# Launch Claude Code with dangerously skip permissions
+alias yoclau='claude --dangerously-skip-permissions'


### PR DESCRIPTION
## Summary
- Adds `yoclau` alias to `~/.zsh_aliases` that runs `claude --dangerously-skip-permissions`
- Updates README.md with the new alias documentation

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)