### PR TITLE
Set default shell to zsh and remove session plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,19 @@ The zsh configuration is portable across macOS and Linux. Platform-specific path
 
 Machine-specific config and secrets can be placed in `~/.zshrc.local` — it is sourced automatically if present.
 
+## Tmux
+
+Terminal multiplexer with session persistence. Plugin manager: [TPM](https://github.com/tmux-plugins/tpm) (auto-bootstraps if missing).
+
+### Features
+
+| Feature | Detail |
+|---------|--------|
+| Default shell | `/bin/zsh` |
+| Mouse support | Enabled |
+| Scrollback | 10,000 lines |
+| Colors | 256-color (`screen-256color`) |
+
 ## Hammerspoon
 
 macOS automation and window management. Requires the **Hyper key** (`Ctrl + Alt + Cmd + Shift`), typically mapped to CapsLock via Karabiner or Raycast.

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -17,21 +17,16 @@ set -g history-limit 10000
 # Ensure terminal colors look correct
 set -g default-terminal "screen-256color"
 
+# Use zsh as the default shell
+set-option -g default-shell /bin/zsh
+
 # ==========================================
 # 3. PLUGINS
 # ==========================================
 set -g @plugin 'tmux-plugins/tpm'
-set -g @plugin 'tmux-plugins/tmux-resurrect'
-set -g @plugin 'tmux-plugins/tmux-continuum'
 
 # ==========================================
-# 4. PLUGIN CONFIGURATION
-# ==========================================
-# Restore last saved environment (automatically)
-set -g @continuum-restore 'on'
-
-# ==========================================
-# 5. INITIALIZE TPM
+# 4. INITIALIZE TPM
 # (Keep this line at the very bottom of tmux.conf)
 # ==========================================
 run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## Summary
- Add `set-option -g default-shell /bin/zsh` so tmux always uses zsh regardless of when the server was started
- Remove tmux-resurrect and tmux-continuum plugins (no longer needed)
- Add Tmux section to README with feature overview

Closes #38, closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)