### PR TITLE
Move word nav shortcuts to Karabiner for universal terminal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Personal macOS dotfiles managed with [GNU Stow](https://www.gnu.org/software/sto
 dotfiles/
 ├── claude/         # Global Claude Code instructions
 ├── hammerspoon/    # macOS automation & window management
+├── karabiner/      # Keyboard remapping (Hyper key + word nav)
 ├── tmux/           # Terminal multiplexer
 ├── vim/            # Vim editor
 └── zsh/            # Zsh shell
@@ -121,6 +122,34 @@ The zsh configuration is portable across macOS and Linux. Platform-specific path
 
 Machine-specific config and secrets can be placed in `~/.zshrc.local` — it is sourced automatically if present.
 
+## Karabiner
+
+Keyboard remapping via [Karabiner-Elements](https://karabiner-elements.pqrs.org/).
+
+### Hyper Key
+
+CapsLock is mapped to `Ctrl+Alt+Cmd+Shift` (the "Hyper" key), used as a modifier for Hammerspoon and Karabiner shortcuts.
+
+### Word Navigation (via Karabiner)
+
+These shortcuts are handled by Karabiner at the HID level (not Hammerspoon) so that iTerm2's Esc+ setting translates them into Meta escape sequences. This makes them work in both zsh and TUI apps like Claude Code.
+
+| Shortcut | Output | Action |
+|----------|--------|--------|
+| `Hyper + b` | `Option+B` | Jump one word backward |
+| `Hyper + w` | `Option+F` | Jump one word forward |
+| `Hyper + d` | `Right`, `Option+B`, `Option+D` | Delete word under cursor |
+
+### iTerm2 Setup (required)
+
+Set the Left Option key to **Esc+** so that Option+letter produces Meta escape sequences instead of special characters (e.g., `\eb` instead of `∫`):
+
+1. Open **iTerm2 → Preferences** (Cmd+,)
+2. Go to **Profiles → Keys**
+3. Set **Left Option Key** to **Esc+**
+
+This is required for the Karabiner word navigation shortcuts above. It also enables physical Option+Left/Right/Backspace for word navigation in all terminal apps.
+
 ## Tmux
 
 Terminal multiplexer with session persistence. Plugin manager: [TPM](https://github.com/tmux-plugins/tpm) (auto-bootstraps if missing).
@@ -181,10 +210,10 @@ macOS automation and window management. Requires the **Hyper key** (`Ctrl + Alt 
 |----------|--------|
 | `Hyper + a` | Beginning of line (`Ctrl+A`) |
 | `Hyper + e` | End of line (`Ctrl+E`) |
-| `Hyper + b` | Jump one word backward (`Ctrl+B` → zsh `backward-word`) |
-| `Hyper + w` | Jump one word forward (`Ctrl+F` → zsh `forward-word`) |
-| `Hyper + d` | Delete word under cursor (`Ctrl+G` → zsh custom widget) |
-| `Hyper + u` | Delete to beginning of line (`Ctrl+U` → zsh `backward-kill-line`) |
+| `Hyper + b` | Jump one word backward (Karabiner → `Option+B`) |
+| `Hyper + w` | Jump one word forward (Karabiner → `Option+F`) |
+| `Hyper + d` | Delete word under cursor (Karabiner → `Option+B` then `Option+D`) |
+| `Hyper + u` | Delete to beginning of line (`Ctrl+U`) |
 | `Hyper + x` | Delete to end of line (`Ctrl+K`) |
 
 > **Mnemonic**: **B**ack a word / forward a **W**ord. **D**elete the word. **U**ndo what you typed (wipes left). **X** out the rest (wipes right).

--- a/hammerspoon/.hammerspoon/hyper_vim.lua
+++ b/hammerspoon/.hammerspoon/hyper_vim.lua
@@ -122,32 +122,11 @@ function M.start(opts)
       return true
     end
 
-    -- Hyper+B/W: word jumping via Ctrl+B / Ctrl+F.
-    -- Sending Option+Arrow or Esc+letter from an eventtap is unreliable
-    -- because terminals can't properly receive modifier flags or multi-key
-    -- sequences from synthetic events. Instead, we send Ctrl+B/F (which
-    -- works the same way as the proven Ctrl+A/E) and rebind them in zsh
-    -- from single-char movement to word movement (the user already has
-    -- Hyper+H/L for single-char navigation via arrow keys).
-    if key == "b" then
-      local events = sendCtrlKey("b")
-      if events then return true, events end
-      return true
-    end
-    if key == "w" then
-      local events = sendCtrlKey("f")
-      if events then return true, events end
-      return true
-    end
-
-    -- Hyper+D: delete word under cursor via Ctrl+G.
-    -- Ctrl+G is rebound in zsh to a custom widget that combines
-    -- backward-word + kill-word to delete the entire word.
-    if key == "d" then
-      local events = sendCtrlKey("g")
-      if events then return true, events end
-      return true
-    end
+    -- Hyper+B/W/D: word navigation and deletion.
+    -- These are handled by Karabiner at the HID level (not Hammerspoon),
+    -- which outputs Left Option+key events with proper device flags.
+    -- iTerm2's Esc+ setting then translates them into Meta escape sequences
+    -- (\eb, \ef, \ed) that work in both zsh and TUI apps like Claude Code.
 
     -- Hyper+U/X: delete to beginning/end of line.
     -- Ctrl+K is zsh's default kill-line (cursor to end).

--- a/karabiner/.config/karabiner/karabiner.json
+++ b/karabiner/.config/karabiner/karabiner.json
@@ -1,0 +1,95 @@
+{
+    "profiles": [
+        {
+            "complex_modifications": {
+                "rules": [
+                    {
+                        "description": "Hyper + \\ → Ctrl+Cmd+W for Wispr",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "backslash",
+                                    "modifiers": { "mandatory": ["left_control", "left_option", "left_command", "left_shift"] }
+                                },
+                                "to": [
+                                    {
+                                        "key_code": "w",
+                                        "modifiers": ["left_control", "left_command"]
+                                    }
+                                ],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Hyper+B → Option+B (backward-word)",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "b",
+                                    "modifiers": { "mandatory": ["left_control", "left_option", "left_command", "left_shift"] }
+                                },
+                                "to": [{ "key_code": "b", "modifiers": ["left_option"] }],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Hyper+W → Option+F (forward-word)",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "w",
+                                    "modifiers": { "mandatory": ["left_control", "left_option", "left_command", "left_shift"] }
+                                },
+                                "to": [{ "key_code": "f", "modifiers": ["left_option"] }],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Hyper+D → Right, Option+B, Option+D (delete word under cursor)",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "d",
+                                    "modifiers": { "mandatory": ["left_control", "left_option", "left_command", "left_shift"] }
+                                },
+                                "to": [
+                                    { "key_code": "right_arrow" },
+                                    { "key_code": "b", "modifiers": ["left_option"] },
+                                    { "key_code": "d", "modifiers": ["left_option"] }
+                                ],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
+                        "manipulators": [
+                            {
+                                "description": "Change caps_lock to command+control+option+shift.",
+                                "from": {
+                                    "key_code": "caps_lock",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "to": [
+                                    {
+                                        "key_code": "left_shift",
+                                        "modifiers": ["left_command", "left_control", "left_option"]
+                                    }
+                                ],
+                                "type": "basic"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "name": "Default profile",
+            "selected": true,
+            "virtual_hid_keyboard": {
+                "country_code": 0,
+                "keyboard_type_v2": "ansi"
+            }
+        }
+    ]
+}

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -74,20 +74,9 @@ plugins=(git autojump)
 
 source $ZSH/oh-my-zsh.sh
 
-# Rebind Ctrl+B/F from single-char to word movement.
-# Single-char movement is handled by Hyper+H/L (arrow keys via Hammerspoon).
-# Hyper+B sends Ctrl+B and Hyper+W sends Ctrl+F through the eventtap.
-bindkey '^B' backward-word
-bindkey '^F' forward-word
+# Change Ctrl+U from kill-whole-line (zsh default) to backward-kill-line,
+# so it only deletes from cursor to beginning of line (complementing Ctrl+K).
 bindkey '^U' backward-kill-line
-
-# Delete word under cursor (Hyper+D sends Ctrl+G via Hammerspoon).
-delete-word-under-cursor() {
-  zle backward-word
-  zle kill-word
-}
-zle -N delete-word-under-cursor
-bindkey '^G' delete-word-under-cursor
 
 # User configuration
 


### PR DESCRIPTION
## Summary
- Move Hyper+B/W/D from Hammerspoon (CGEvent level) to Karabiner (HID level) so they work in both zsh and Claude Code CLI
- Add Karabiner config to dotfiles, managed via Stow
- Remove zsh `bindkey` remappings and custom widget that are no longer needed
- Document Karabiner setup and iTerm2 Esc+ requirement in README

## Why Karabiner?
Hammerspoon's synthetic CGEvents lack the Left Option device flag (`NX_DEVICELALTKEYMASK`) that iTerm2 checks when deciding whether to apply its Esc+ setting. Karabiner operates at the HID level and creates events with proper device flags, so iTerm2 correctly translates Option+letter into Meta escape sequences (`\eb`, `\ef`, `\ed`) as single pty writes. See [issue comment](https://github.com/abhirama/dotfiles/issues/41#issuecomment-3908857262) for the full root cause analysis.

## Test plan
- [x] Hyper+B/W/D work in zsh shell
- [x] Hyper+B/W/D work in Claude Code CLI
- [x] Hyper+U/X still work in both
- [x] Karabiner config symlinked via Stow

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)