### PR TITLE
Add iTerm2 tab title and session listing to d() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ Framework: [oh-my-zsh](https://ohmyz.sh/) with the `robbyrussell` theme.
 
 | Function | Usage | Description |
 |----------|-------|-------------|
-| `d [session]` | `d` or `d work` | SSH to host `d` and attach to a tmux session (defaults to `main`) |
+| `d [session]` | `d` or `d work` | SSH to host `d` and attach to a tmux session (defaults to `main`). Sets iTerm2 tab/pane title to session name |
+| `d -l` | `d -l` | List active tmux sessions on remote host `d` |
 
 ### Cross-Platform Support
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -122,10 +122,16 @@ export PATH="$HOME/bin:$PATH"
 [ -d "/usr/local/opt/postgresql@16" ] && export PATH="/usr/local/opt/postgresql@16/bin:$PATH"
 
 # SSH to 'd', attaching to a tmux session (creates if missing). Defaults to 'main'.
+# Sets iTerm2 tab/pane title to the session name for easy identification.
+# Use -l to list active tmux sessions on the remote host.
 function d() {
-    # No outer quotes around the command.
-    # Let SSH handle the argument passing.
-    ssh -t d tmux new-session -A -s "${1:-main}"
+    if [[ "$1" == "-l" ]]; then
+        ssh d tmux list-sessions
+        return
+    fi
+    local session="${1:-main}"
+    printf '\e]0;%s\a' "$session"
+    ssh -t d tmux new-session -A -s "$session"
 }
 
 # Entire CLI shell completion


### PR DESCRIPTION
## Summary
- Set iTerm2 tab/pane title to the session name when connecting via `d`, making it easy to identify tabs across multiple remote tmux sessions
- Add `d -l` flag to list active tmux sessions on the remote host

Closes #43
Closes #44

## Test plan
- [x] `d foo` sets iTerm2 tab/pane title to `foo`
- [x] `d` defaults to session `main` and sets title accordingly
- [x] `d -l` lists active remote tmux sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)