### PR TITLE
Add iTerm2 tab management shortcuts (Hyper+T/N/P/Q)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,17 @@ macOS automation and window management. Requires the **Hyper key** (`Ctrl + Alt 
 
 > **Mnemonic**: **B**ack a word / forward a **W**ord. **D**elete the word. **U**ndo what you typed (wipes left). **X** out the rest (wipes right).
 
+### iTerm2 Tab Management
+
+These shortcuts only activate when iTerm2 is the frontmost app. Tab cycling wraps around (circular buffer).
+
+| Shortcut | Action | Mnemonic |
+|----------|--------|----------|
+| `Hyper + t` | New tab | **T**ab |
+| `Hyper + n` | Next tab (wraps around) | **N**ext |
+| `Hyper + p` | Previous tab (wraps around) | **P**revious |
+| `Hyper + q` | Close tab | **Q**uit |
+
 ### Utilities
 
 | Shortcut | Action |


### PR DESCRIPTION
## Summary

- **Hyper+T**: New tab in iTerm2 (sends `Cmd+T`)
- **Hyper+N**: Next tab with circular wrap-around
- **Hyper+P**: Previous tab with circular wrap-around
- **Hyper+Q**: Close tab (sends `Cmd+W`)

All shortcuts are context-aware — they only activate when iTerm2 is the frontmost app and pass through in all other apps. Tab cycling uses AppleScript for wrap-around behavior since native `Cmd+Shift+]/[` stops at boundaries.

## Test plan

- [x] Hyper+T opens a new tab in iTerm2
- [x] Hyper+N cycles to next tab, wraps from last → first
- [x] Hyper+P cycles to previous tab, wraps from first → last
- [x] Hyper+Q closes the current tab
- [x] All shortcuts pass through when iTerm2 is not frontmost

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)