### PR TITLE
Add Chrome tab management shortcuts (Hyper+T/N/P/Q)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,9 @@ macOS automation and window management. Requires the **Hyper key** (`Ctrl + Alt 
 
 > **Mnemonic**: **B**ack a word / forward a **W**ord. **D**elete the word. **U**ndo what you typed (wipes left). **X** out the rest (wipes right).
 
-### iTerm2 Tab Management
+### Tab Management (iTerm2 & Chrome)
 
-These shortcuts only activate when iTerm2 is the frontmost app. Tab cycling wraps around (circular buffer).
+These shortcuts only activate when iTerm2 or Chrome is the frontmost app. Tab cycling wraps around (circular buffer).
 
 | Shortcut | Action | Mnemonic |
 |----------|--------|----------|


### PR DESCRIPTION
## Summary
- Replicate iTerm2 tab management shortcuts for Chrome (Hyper+T/N/P/Q)
- Chrome tab cycling uses AppleScript with `active tab index` for wrap-around behavior
- Context-aware: shortcuts only activate when iTerm2 or Chrome is frontmost

## Test plan
- [x] Hyper+T opens new tab in Chrome
- [x] Hyper+N cycles to next tab (wraps from last to first)
- [x] Hyper+P cycles to previous tab (wraps from first to last)
- [x] Hyper+Q closes current tab in Chrome
- [x] iTerm2 tab shortcuts still work as before
- [x] Shortcuts pass through in other apps

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)