### PR TITLE
Add Hyper+' shortcut for Cmd+Tab app switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ macOS automation and window management. Requires the **Hyper key** (`Ctrl + Alt 
 | Shortcut | Action |
 |----------|--------|
 | `Hyper + Return` | Toggle Raycast |
+| `Hyper + '` | Switch to last used app (`Cmd+Tab`) |
 
 ### Line Navigation
 

--- a/hammerspoon/.hammerspoon/hyper_vim.lua
+++ b/hammerspoon/.hammerspoon/hyper_vim.lua
@@ -242,6 +242,13 @@ function M.start(opts)
       return true
     end
 
+    -- Hyper+': app switching (Cmd+Tab) — switch to most recently used app.
+    if key == "'" then
+      local events = sendCmdKey("tab")
+      if events then return true, events end
+      return true
+    end
+
     -- Hyper+T/N/P/Q: Tab management for iTerm2 and Chrome.
     -- T = new tab, N = next tab (wrap), P = previous tab (wrap), Q = close tab.
     -- Context-aware: only activates when iTerm2 or Chrome is frontmost.


### PR DESCRIPTION
## Summary
- Map Hyper+' (apostrophe) to Cmd+Tab for quick app switching
- Works globally — switches to the most recently used application

## Test plan
- [x] Hyper+' switches to the last used app
- [x] Existing Hyper shortcuts unaffected (U, X, T, N, P, Q, etc.)

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)