### PR TITLE
Move tailscale alias from .zshrc to .zsh_aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Framework: [oh-my-zsh](https://ohmyz.sh/) with the `robbyrussell` theme.
 | `dpush` | `rsync -avzP ~/do-sync/ d:~/do-sync/` | Push files from local Mac to DigitalOcean |
 | `dpull` | `rsync -avzP d:~/do-sync/ ~/do-sync/` | Pull files from DigitalOcean to local Mac |
 | `yoclau` | `claude --dangerously-skip-permissions` | Launch Claude Code with dangerously skip permissions |
+| `tailscale` | `/Applications/Tailscale.app/Contents/MacOS/Tailscale` | Tailscale CLI (macOS app bundle) |
 
 ### Functions
 

--- a/zsh/.zsh_aliases
+++ b/zsh/.zsh_aliases
@@ -14,3 +14,6 @@ alias dpull='rsync -avzP d:~/do-sync/ ~/do-sync/'
 
 # Launch Claude Code with dangerously skip permissions
 alias yoclau='claude --dangerously-skip-permissions'
+
+# Tailscale CLI (macOS app bundle)
+alias tailscale="/Applications/Tailscale.app/Contents/MacOS/Tailscale"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -166,5 +166,3 @@ function d() {
 
 # Entire CLI shell completion
 command -v entire &>/dev/null && source <(entire completion zsh)
-
-alias tailscale="/Applications/Tailscale.app/Contents/MacOS/Tailscale"


### PR DESCRIPTION
## Summary

- Moves the `tailscale` alias from `.zshrc` to `.zsh_aliases` for consistency with all other aliases
- Documents the alias in README.md

Closes #56

## Test plan

- [x] `tailscale version` works after sourcing

🤖 Generated with [Claude Code](https://claude.com/claude-code)