### PR TITLE
Add Hyper+/ for window switching and karabiner-sync function

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ Framework: [oh-my-zsh](https://ohmyz.sh/) with the `robbyrussell` theme.
 |----------|-------|-------------|
 | `d [session]` | `d` or `d work` | SSH to host `d` and attach to a tmux session (defaults to `main`). Sets iTerm2 tab/pane title to session name |
 | `d -l` | `d -l` | List active tmux sessions on remote host `d` |
+| `karabiner-sync` | `karabiner-sync` | Show diff between dotfiles and live Karabiner config, choose sync direction |
+| `karabiner-sync push` | `karabiner-sync push` | Copy dotfiles config → Karabiner |
+| `karabiner-sync pull` | `karabiner-sync pull` | Copy live Karabiner config → dotfiles |
 
 ### Cross-Platform Support
 
@@ -141,6 +144,12 @@ These shortcuts are handled by Karabiner at the HID level (not Hammerspoon) so t
 | `Hyper + b` | `Option+B` (Meta `\eb`, word backward to delimiter) | `Option+Left` (word backward) |
 | `Hyper + w` | `Option+F` (Meta `\ef`, word forward to delimiter) | `Option+Right` (word forward) |
 | `Hyper + d` | `Ctrl+W` (delete word backward) | `Option+Backspace` (delete word backward) |
+
+### Window Switching (via Karabiner)
+
+| Shortcut | Action |
+|----------|--------|
+| `Hyper + /` | `` Cmd+` `` (cycle windows of current app) |
 
 ### iTerm2 Setup (required)
 
@@ -206,6 +215,7 @@ macOS automation and window management. Requires the **Hyper key** (`Ctrl + Alt 
 |----------|--------|
 | `Hyper + Return` | Toggle Raycast |
 | `Hyper + '` | Switch to last used app (`Cmd+Tab`) |
+| `Hyper + /` | Switch to next window of current app (`` Cmd+` ``, via Karabiner) |
 
 ### Line Navigation
 

--- a/hammerspoon/.hammerspoon/hyper_vim.lua
+++ b/hammerspoon/.hammerspoon/hyper_vim.lua
@@ -251,6 +251,10 @@ function M.start(opts)
       return true
     end
 
+    -- Hyper+/: window switching (Cmd+`) — handled by Karabiner at the HID
+    -- level because the slash key with Hyper (which includes shift) doesn't
+    -- reach Hammerspoon's eventtap.
+
     -- Hyper+T/N/P/Q: Tab management for iTerm2 and Chrome.
     -- T = new tab, N = next tab (wrap), P = previous tab (wrap), Q = close tab.
     -- Context-aware: only activates when iTerm2 or Chrome is frontmost.

--- a/karabiner/.config/karabiner/karabiner.json
+++ b/karabiner/.config/karabiner/karabiner.json
@@ -112,6 +112,19 @@
                         ]
                     },
                     {
+                        "description": "Hyper+/ → Cmd+` (cycle windows of current app)",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "slash",
+                                    "modifiers": { "mandatory": ["left_control", "left_option", "left_command", "left_shift"] }
+                                },
+                                "to": [{ "key_code": "grave_accent_and_tilde", "modifiers": ["left_command"] }],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
                         "manipulators": [
                             {
                                 "description": "Change caps_lock to command+control+option+shift.",

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -164,5 +164,35 @@ function d() {
     ssh -t d tmux new-session -A -s "$session"
 }
 
+# Bidirectional Karabiner config sync.
+# Karabiner-Elements overwrites symlinks, so Stow can't manage this config.
+# Usage: karabiner-sync         (show diff and choose direction)
+#        karabiner-sync push    (dotfiles → karabiner)
+#        karabiner-sync pull    (karabiner → dotfiles)
+function karabiner-sync() {
+    local dotfile=~/dotfiles/karabiner/.config/karabiner/karabiner.json
+    local config=~/.config/karabiner/karabiner.json
+
+    if diff -q "$dotfile" "$config" &>/dev/null; then
+        echo "Already in sync"
+        return
+    fi
+
+    local choice="$1"
+    if [[ -z "$choice" ]]; then
+        diff --color "$dotfile" "$config"
+        echo ""
+        echo "  push) dotfiles → karabiner"
+        echo "  pull) karabiner → dotfiles"
+        read "choice?Direction [push/pull]: "
+    fi
+
+    case "$choice" in
+        push) cp "$dotfile" "$config" && echo "Pushed: dotfiles → karabiner" ;;
+        pull) cp "$config" "$dotfile" && echo "Pulled: karabiner → dotfiles" ;;
+        *) echo "Aborted" ;;
+    esac
+}
+
 # Entire CLI shell completion
 command -v entire &>/dev/null && source <(entire completion zsh)


### PR DESCRIPTION
## Summary

- **Hyper+/**: Maps to `Cmd+`` (cycle windows of current app) via Karabiner, since the slash key with Hyper modifiers doesn't reach Hammerspoon's eventtap
- **karabiner-sync**: Bidirectional sync function for Karabiner config, since Karabiner overwrites symlinks and can't be managed by Stow. Supports `push` (dotfiles → karabiner), `pull` (karabiner → dotfiles), or interactive mode with diff

Closes #58

## Test plan

- [x] Hyper+/ cycles windows of current app
- [x] `karabiner-sync` shows "Already in sync" when files match
- [x] Interactive mode shows diff and direction prompt when files differ

🤖 Generated with [Claude Code](https://claude.com/claude-code)