### PR TITLE
Add mosh equivalent of d function as m

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ Each directory contains dotfiles that Stow will symlink to `~` (home directory).
 - `vz`: Navigate with zoxide and open Vim
 - `claude`: Launch Claude CLI with Opus planning mode
 - `d [session]`: SSH to host 'd' with tmux session (defaults to 'main')
+- `m [session]`: Mosh to host 'd' with tmux session (defaults to 'main')
 
 **Local Overrides**: Sources `~/.zshrc.local` for machine-specific configs/secrets
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Framework: [oh-my-zsh](https://ohmyz.sh/) with the `robbyrussell` theme.
 |----------|-------|-------------|
 | `d [session]` | `d` or `d work` | SSH to host `d` and attach to a tmux session (defaults to `main`). Sets iTerm2 tab/pane title to session name |
 | `d -l` | `d -l` | List active tmux sessions on remote host `d` |
+| `m [session]` | `m` or `m work` | Mosh to host `d` and attach to a tmux session (defaults to `main`). Sets iTerm2 tab/pane title to session name |
+| `m -l` | `m -l` | List active tmux sessions on remote host `d` |
 | `karabiner-sync` | `karabiner-sync` | Show diff between dotfiles and live Karabiner config, choose sync direction |
 | `karabiner-sync push` | `karabiner-sync push` | Copy dotfiles config → Karabiner |
 | `karabiner-sync pull` | `karabiner-sync pull` | Copy live Karabiner config → dotfiles |

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -164,6 +164,18 @@ function d() {
     ssh -t d tmux new-session -A -s "$session"
 }
 
+# Mosh equivalent of d(). Uses mosh for the connection but still uses ssh for
+# listing sessions since mosh doesn't support non-interactive commands.
+function m() {
+    if [[ "$1" == "-l" ]]; then
+        ssh d tmux list-sessions
+        return
+    fi
+    local session="${1:-main}"
+    printf '\e]0;%s\a' "$session"
+    mosh d -- tmux new-session -A -s "$session"
+}
+
 # Bidirectional Karabiner config sync.
 # Karabiner-Elements overwrites symlinks, so Stow can't manage this config.
 # Usage: karabiner-sync         (show diff and choose direction)


### PR DESCRIPTION
## Summary
- Add `m` function that mirrors `d` but uses `mosh` instead of `ssh` for connecting to remote host
- `m -l` still uses SSH for listing sessions since mosh doesn't support non-interactive commands
- Update README.md and CLAUDE.md with new function documentation

Closes #60

## Test plan
- [x] `m` connects via mosh and attaches to `main` tmux session
- [x] `m -l` lists remote tmux sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)